### PR TITLE
Added new field, `isPortalIntegrated` to the health endpoint response.

### DIFF
--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -143,6 +143,7 @@ def check_service_health(service_infos, access_token):
         component_category = service_info_dict.get("componentCategory", "general")
         component_type = service_info_dict.get("componentType", "unknown")
         description = service_info_dict.get("description", "")
+        is_portal_integrated = service_info_dict.get("isPortalIntegrated", False)
 
         try:
             response = requests.get(health_check_url, headers=headers)
@@ -161,6 +162,7 @@ def check_service_health(service_infos, access_token):
                 "description": description,
                 "ssmKey": ssm_key,
                 "healthCheckUrl": health_check_url,
+                "isPortalIntegrated": is_portal_integrated,
                 "landingPageUrl": landing_page_url,
                 "healthChecks": [
                     {


### PR DESCRIPTION
Added new field, `isPortalIntegrated` to each of the items in the health endpoint response. The field's value is defaulted to `false`. This field describes if the respective service has been integrated with the portal, meaning, if the service is a UI, it can be opened in the portal's web view rather than in a new window when the fields value is set to `true`. If the field is set to `false`, the UI will always open in a new window.

Related ticket: https://github.com/unity-sds/ui-ux/issues/8